### PR TITLE
Make KaosTestClass persist database between unit tests.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ email-validator==1.0.2
 enum34==1.1.6
 Flask==1.0.2
 Flask-SQLAlchemy==2.3.2
-Flask-Testing==0.7.1
 Flask-Validator==1.2.3
 funcsigs==1.0.2
 futures==3.2.0

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,20 +1,41 @@
 """Defines the base classes to be used in testing KAOS."""
 
-from flask_testing import TestCase
+from unittest import TestCase
 
 from .context import kaos
 from kaos import create_app
 from kaos.models import DB
 
 class KaosTestCase(TestCase):
-    """Test classes subclasing this class will have the DB recreaetd in between test cases."""
+    """Test class that provides DB setup and teardown at the beginning and end of a test case."""
 
-    def create_app(self):
+    @staticmethod
+    def create_app():
         return create_app("settings_test.cfg")
 
+    @classmethod
+    def setUpClass(cls):
+        cls.app = KaosTestCase.create_app()
+        cls.client = cls.app.test_client()
+        
+        cls.app.app_context().push()
+        DB.create_all()
+
+    @classmethod
+    def tearDownClass(cls):
+        DB.session.rollback()
+        DB.session.commit()
+        DB.session.remove()
+        DB.drop_all()
+
+class KaosTestCaseNonPersistent(KaosTestCase):
+    """Test classes subclassing this class will have the DB recreated in between each test."""
+    
     def setUp(self):
         DB.create_all()
 
     def tearDown(self):
-        DB.session.remove()
+        DB.session.rollback()
+        DB.session.commit()
         DB.drop_all()
+

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -2,11 +2,11 @@
 
 from sqlalchemy.exc import IntegrityError, ProgrammingError
 
-from . import KaosTestCase
+from . import KaosTestCaseNonPersistent
 from .context import kaos
 from kaos.models import *
 
-class TestResponseHistory(KaosTestCase):
+class TestResponseHistory(KaosTestCaseNonPersistent):
     """Ensures that the response history table behaves as expected."""
 
     def test_history_empty(self):
@@ -102,3 +102,4 @@ class TestResponseHistory(KaosTestCase):
         for q_min, q_max in zip(query_min, query_max):
             self.assertTrue(q_min.start_time == start)
             self.assertTrue(q_max.end_time == end)
+

--- a/test/test_kaos.py
+++ b/test/test_kaos.py
@@ -18,3 +18,4 @@ class TestApi(KaosTestCase):
         with self.app.test_client() as client:
             response = client.get('/api/')
             self.assertTrue(response.data == "Bad API request, no satellites for you.")
+

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -5,12 +5,12 @@ from collections import namedtuple
 from kaos.models import *
 from kaos.parser import *
 
-from . import KaosTestCase
+from . import KaosTestCaseNonPersistent
 from .context import kaos
 
 OrbitPoint = namedtuple('OrbitPoint', 'time, pos, vel')
 
-class TestEphemerisParser(KaosTestCase):
+class TestEphemerisParser(KaosTestCaseNonPersistent):
     """Ensures that the ephemeris parser behaves as expected."""
 
     def test_db_add_correct_num_rows(self):


### PR DESCRIPTION
Add new KaosTestClassNonPersistent for test cases that require the
database to be cleared between individual unit tests.